### PR TITLE
Fix daily APY calculation and fix Basset decimals

### DIFF
--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -1,0 +1,8 @@
+### v.NEXT
+
+- Change `SavingsContract.dailyAPY` to a simple (`BigDecimal`) value and ensure the value is set properly
+- Fix an issue where vault balances of bAssets were set with the wrong decimals
+
+### v0.1.0
+
+- Initial release

--- a/packages/protocol/schema.generated.graphql
+++ b/packages/protocol/schema.generated.graphql
@@ -447,7 +447,7 @@ type SavingsContract @entity {
     The daily APY value; this is derived from the `ExchangeRate` closest to 24h ago from the last-received
     `ExchangeRate`, and will change whenever a new `ExchangeRate` is created.
     """
-    dailyAPY: Metric!
+    dailyAPY: BigDecimal!
 
     """
     The share of the Masset that is deposited in the Savings Contract; a rate of 100% would mean all of the

--- a/packages/protocol/schema.graphql
+++ b/packages/protocol/schema.graphql
@@ -332,7 +332,7 @@ type SavingsContract @entity {
     The daily APY value; this is derived from the `ExchangeRate` closest to 24h ago from the last-received
     `ExchangeRate`, and will change whenever a new `ExchangeRate` is created.
     """
-    dailyAPY: Metric!
+    dailyAPY: BigDecimal!
 
     """
     The share of the Masset that is deposited in the Savings Contract; a rate of 100% would mean all of the

--- a/packages/protocol/src/Basket.ts
+++ b/packages/protocol/src/Basket.ts
@@ -29,25 +29,37 @@ export function updateBassetEntities(basketManager: BasketManager): Array<Basset
     arr[i].ratio = basset.ratio
     arr[i].maxWeight = basset.maxWeight
 
-    arr[i].vaultBalance = metrics.getOrCreate(bassetAddress, 'vaultBalance', decimals).id
+    arr[i].vaultBalance = metrics.getOrCreateWithDecimals(
+      bassetAddress,
+      'vaultBalance',
+      decimals,
+    ).id
     metrics.updateById(arr[i].vaultBalance, basset.vaultBalance)
 
     arr[i].isTransferFeeCharged = basset.isTransferFeeCharged
     arr[i].status = mapBassetStatus(basset.status)
 
-    arr[i].totalSupply = metrics.getOrCreate(bassetAddress, 'token.totalSupply').id
-    arr[i].cumulativeMinted = metrics.getOrCreate(bassetAddress, 'cumulativeMinted', decimals).id
-    arr[i].cumulativeRedeemed = metrics.getOrCreate(
+    arr[i].totalSupply = metrics.getOrCreateWithDecimals(
+      bassetAddress,
+      'token.totalSupply',
+      decimals,
+    ).id
+    arr[i].cumulativeMinted = metrics.getOrCreateWithDecimals(
+      bassetAddress,
+      'cumulativeMinted',
+      decimals,
+    ).id
+    arr[i].cumulativeRedeemed = metrics.getOrCreateWithDecimals(
       bassetAddress,
       'cumulativeRedeemed',
       decimals,
     ).id
-    arr[i].cumulativeFeesPaid = metrics.getOrCreate(
+    arr[i].cumulativeFeesPaid = metrics.getOrCreateWithDecimals(
       bassetAddress,
       'cumulativeFeesPaid',
       decimals,
     ).id
-    arr[i].cumulativeSwappedAsOutput = metrics.getOrCreate(
+    arr[i].cumulativeSwappedAsOutput = metrics.getOrCreateWithDecimals(
       bassetAddress,
       'cumulativeSwappedAsOutput',
       decimals,

--- a/packages/protocol/src/Basket.ts
+++ b/packages/protocol/src/Basket.ts
@@ -34,7 +34,7 @@ export function updateBassetEntities(basketManager: BasketManager): Array<Basset
       'vaultBalance',
       decimals,
     ).id
-    metrics.updateById(arr[i].vaultBalance, basset.vaultBalance)
+    metrics.updateByIdWithDecimals(arr[i].vaultBalance, basset.vaultBalance, decimals)
 
     arr[i].isTransferFeeCharged = basset.isTransferFeeCharged
     arr[i].status = mapBassetStatus(basset.status)

--- a/packages/protocol/src/SavingsContract.ts
+++ b/packages/protocol/src/SavingsContract.ts
@@ -1,5 +1,5 @@
 import { Address } from '@graphprotocol/graph-ts'
-import { counters, metrics } from '@mstable/subgraph-utils'
+import { counters, decimal, metrics } from '@mstable/subgraph-utils'
 
 import { SavingsContract as SavingsContractEntity } from '../generated/schema'
 
@@ -24,7 +24,7 @@ export function createSavingsContract(
   savingsContractEntity.totalCredits = metrics.getOrCreate(address, 'totalCredits').id
   savingsContractEntity.totalSavings = metrics.getOrCreate(address, 'totalSavings').id
   savingsContractEntity.utilisationRate = metrics.getOrCreate(address, 'utilisationRate').id
-  savingsContractEntity.dailyAPY = metrics.getOrCreate(address, 'dailyAPY').id
+  savingsContractEntity.dailyAPY = decimal.ZERO
 
   savingsContractEntity.totalDeposits = counters.getOrCreate(address, 'totalDeposits').id
   savingsContractEntity.totalWithdrawals = counters.getOrCreate(address, 'totalWithdrawals').id

--- a/packages/protocol/src/mappings/SavingsContract.ts
+++ b/packages/protocol/src/mappings/SavingsContract.ts
@@ -46,9 +46,9 @@ function calculateAPY(start: ExchangeRateEntity, end: ExchangeRateEntity): BigIn
   let portionsInYearI32 = portionsInYear.toI32()
   let rateF64 = parseFloat(rateDiff.toString())
   let apyF64 = rateF64 ** portionsInYearI32
-  let apyPercentage = apyF64 - 1
+  let apyDecimal = decimal.fromNumber(apyF64 - 1)
 
-  return decimal.fromNumber(apyPercentage).digits.times(integer.fromNumber(100))
+  return integer.fromString(apyDecimal.digits.toString())
 }
 
 export function handleExchangeRateUpdated(event: ExchangeRateUpdated): void {

--- a/packages/utils/src/metrics.ts
+++ b/packages/utils/src/metrics.ts
@@ -11,14 +11,18 @@ export namespace metrics {
       .concat(type)
   }
 
-  export function getOrCreate(
+  export function getOrCreate(address: Address, type: string): MetricEntity {
+    return getOrCreateWithDecimals(address, type, decimal.DEFAULT_DECIMALS)
+  }
+
+  export function getOrCreateWithDecimals(
     address: Address,
     type: string,
     // @ts-ignore
-    decimals: i32 = decimal.DEFAULT_DECIMALS,
+    decimals: i32,
   ): MetricEntity {
     let id = getId(address, type)
-    return getOrCreateById(id, decimals)
+    return getOrCreateByIdWithDecimals(id, decimals)
   }
 
   export function increment(address: Address, type: string, delta: BigInt): MetricEntity {
@@ -36,10 +40,14 @@ export namespace metrics {
     return updateById(id, value)
   }
 
-  export function getOrCreateById(
+  export function getOrCreateById(id: string): MetricEntity {
+    return getOrCreateByIdWithDecimals(id, decimal.DEFAULT_DECIMALS)
+  }
+
+  export function getOrCreateByIdWithDecimals(
     id: string,
     // @ts-ignore
-    decimals: i32 = decimal.DEFAULT_DECIMALS,
+    decimals: i32,
   ): MetricEntity {
     let metricEntity = MetricEntity.load(id)
 
@@ -74,11 +82,15 @@ export namespace metrics {
     return metricEntity as MetricEntity
   }
 
-  export function updateById(
+  export function updateById(id: string, exact: BigInt): MetricEntity {
+    return updateByIdWithDecimals(id, exact, decimal.DEFAULT_DECIMALS)
+  }
+
+  export function updateByIdWithDecimals(
     id: string,
     exact: BigInt,
     // @ts-ignore
-    decimals: i32 = decimal.DEFAULT_DECIMALS,
+    decimals: i32,
   ): MetricEntity {
     let metricEntity = new MetricEntity(id)
 

--- a/packages/utils/src/token.ts
+++ b/packages/utils/src/token.ts
@@ -23,12 +23,24 @@ export namespace token {
       tokenEntity.symbol = contract.symbol()
       tokenEntity.name = contract.name()
 
-      tokenEntity.totalSupply = metrics.getOrCreate(tokenAddress, 'token.totalSupply', decimals).id
-      tokenEntity.totalBurned = metrics.getOrCreate(tokenAddress, 'token.totalBurned', decimals).id
-      tokenEntity.totalMinted = metrics.getOrCreate(tokenAddress, 'token.totalMinted', decimals).id
+      tokenEntity.totalSupply = metrics.getOrCreateWithDecimals(
+        tokenAddress,
+        'token.totalSupply',
+        decimals,
+      ).id
+      tokenEntity.totalBurned = metrics.getOrCreateWithDecimals(
+        tokenAddress,
+        'token.totalBurned',
+        decimals,
+      ).id
+      tokenEntity.totalMinted = metrics.getOrCreateWithDecimals(
+        tokenAddress,
+        'token.totalMinted',
+        decimals,
+      ).id
 
       let totalSupply = contract.totalSupply()
-      metrics.updateById(tokenEntity.totalSupply, totalSupply)
+      metrics.updateByIdWithDecimals(tokenEntity.totalSupply, totalSupply, decimals)
 
       tokenEntity.totalTransfers = counters.getOrCreate(tokenAddress, 'token.totalTransfers').id
       tokenEntity.totalMints = counters.getOrCreate(tokenAddress, 'token.totalMints').id


### PR DESCRIPTION
SAVE APY (breaking change):

- Use a simple (`BigDecimal`) value for the daily APY
- Ensure the value is set correctly

Decimals for metrics:

- Ensure that Basset metrics are created with the correct decimals
- Add methods to the metrics to create and update metrics with given decimals; otherwise use the default
- Ensure that token decimals are used for metrics
