### PR TITLE
Fix: Handle feeders dual vaults without platform tokens

### DIFF
--- a/config/mainnet.json
+++ b/config/mainnet.json
@@ -66,7 +66,7 @@
     {
       "name": "mBTC/tBTCv2",
       "address": "0x97E2a2F97A2E9a4cFB462a49Ab7c8D205aBB9ed9",
-      "startBlock": 13496580,
+      "startBlock": 13496579,
       "abi": "BoostedDualVault",
       "isDual": true
     },

--- a/packages/feeders/schema.generated.graphql
+++ b/packages/feeders/schema.generated.graphql
@@ -271,6 +271,11 @@ type BoostedSavingsVault @entity {
   id: ID!
 
   """
+  Flag for whether this is a dual savings vault
+  """
+  isDualVault: Boolean
+
+  """
   ID of the vault on the BoostDirector contract
   """
   directorVaultId: Int

--- a/packages/feeders/schema.graphql
+++ b/packages/feeders/schema.graphql
@@ -156,6 +156,11 @@ type BoostedSavingsVault @entity {
   id: ID!
 
   """
+  Flag for whether this is a dual savings vault
+  """
+  isDualVault: Boolean
+
+  """
   ID of the vault on the BoostDirector contract
   """
   directorVaultId: Int

--- a/packages/feeders/src/BoostedSavingsVault.ts
+++ b/packages/feeders/src/BoostedSavingsVault.ts
@@ -10,7 +10,7 @@ import {
 } from '../generated/schema'
 
 export namespace BoostedSavingsVault {
-  export function getOrCreate(addr: Address): BoostedSavingsVaultEntity {
+  export function getOrCreate(addr: Address, isDualVault: boolean): BoostedSavingsVaultEntity {
     let id = addr.toHexString()
 
     let entity = BoostedSavingsVaultEntity.load(id)
@@ -47,6 +47,10 @@ export namespace BoostedSavingsVault {
       entity.feederPool = entity.stakingToken
     }
 
+    if (isDualVault) {
+      entity.isDualVault = isDualVault
+    }
+
     let platformToken = dualVaultContract.try_platformToken()
     if (!platformToken.reverted && platformToken.value.notEqual(address.ZERO_ADDRESS)) {
       entity.totalRaw = dualVaultContract.totalRaw()
@@ -72,7 +76,7 @@ export namespace BoostedSavingsVault {
     entity.rewardPerTokenStored = contract.rewardPerTokenStored()
     entity.totalSupply = contract.totalSupply()
 
-    if (entity.platformRewardsToken) {
+    if (entity.isDualVault) {
       let dualVaultContract = BoostedDualVaultContract.bind(addr)
       entity.totalRaw = dualVaultContract.totalRaw()
       entity.platformRewardRate = dualVaultContract.platformRewardRate()

--- a/packages/feeders/src/BoostedSavingsVaultAccount.ts
+++ b/packages/feeders/src/BoostedSavingsVaultAccount.ts
@@ -75,7 +75,7 @@ export namespace BoostedSavingsVaultAccount {
     entity.boostedBalance = contract.balanceOf(account)
     entity.lastClaim = lastClaim.toI32()
 
-    if (boostedSavingsVaultEntity.platformRewardsToken) {
+    if (boostedSavingsVaultEntity.isDualVault) {
       let dualContract = BoostedDualVault.bind(vaultAddr)
       let userData = dualContract.userData(account)
       entity.rewardPerTokenPaid = userData.value0

--- a/packages/feeders/src/mappings/BoostDirector.ts
+++ b/packages/feeders/src/mappings/BoostDirector.ts
@@ -12,7 +12,7 @@ export function handleWhitelisted(event: Whitelisted): void {
   boostDirectorEntity.save()
 
   // This could also be used to create a template
-  let vaultEntity = BoostedSavingsVault.getOrCreate(event.params.vaultAddress)
+  let vaultEntity = BoostedSavingsVault.getOrCreate(event.params.vaultAddress, false)
   vaultEntity.directorVaultId = event.params.vaultId
   vaultEntity.save()
 }

--- a/packages/feeders/src/mappings/BoostedSavingsVault.ts
+++ b/packages/feeders/src/mappings/BoostedSavingsVault.ts
@@ -25,10 +25,19 @@ import { BoostedSavingsVaultAccount } from '../BoostedSavingsVaultAccount'
 import { FeederPoolAccount } from '../FeederPoolAccount'
 
 export function handleStaked(event: Staked): void {
+  _handleStaked(event, false)
+}
+
+export function handleStakedDual(event: Staked): void {
+  _handleStaked(event, true)
+}
+
+function _handleStaked(event: Staked, isDualVault: boolean): void {
   let boostedSavingsVaultEntity = handleEvent(
     event.address,
     event.block.timestamp,
     event.params.user,
+    isDualVault,
   )
 
   {
@@ -49,7 +58,7 @@ export function handleStaked(event: Staked): void {
 }
 
 export function handleRewardAdded(event: RewardAdded): void {
-  handleEvent(event.address, event.block.timestamp, null)
+  handleEvent(event.address, event.block.timestamp, null, false)
 
   {
     let baseTx = transaction.fromEvent(event)
@@ -69,6 +78,7 @@ export function handleRewardPaid(event: RewardPaid): void {
     event.address,
     event.block.timestamp,
     event.params.user,
+    false,
   )
 
   {
@@ -96,10 +106,19 @@ export function handleRewardPaid(event: RewardPaid): void {
 }
 
 export function handleWithdrawn(event: Withdrawn): void {
+  _handleWithdrawn(event, false)
+}
+
+export function handleWithdrawnDual(event: Withdrawn): void {
+  _handleWithdrawn(event, true)
+}
+
+function _handleWithdrawn(event: Withdrawn, isDualVault: boolean): void {
   let boostedSavingsVaultEntity = handleEvent(
     event.address,
     event.block.timestamp,
     event.params.user,
+    isDualVault,
   )
 
   {
@@ -120,12 +139,20 @@ export function handleWithdrawn(event: Withdrawn): void {
 }
 
 export function handlePoked(event: Poked): void {
+  _handlePoked(event, false)
+}
+
+export function handlePokedDual(event: Poked): void {
+  _handlePoked(event, true)
+}
+
+function _handlePoked(event: Poked, isDualVault: boolean): void {
   // Update the boostedBalance of the poked user
-  handleEvent(event.address, event.block.timestamp, event.params.user)
+  handleEvent(event.address, event.block.timestamp, event.params.user, isDualVault)
 }
 
 export function handleRewardAddedDual(event: RewardAddedDual): void {
-  handleEvent(event.address, event.block.timestamp, null)
+  handleEvent(event.address, event.block.timestamp, null, true)
 
   {
     let baseTx = transaction.fromEvent(event)
@@ -146,6 +173,7 @@ export function handleRewardPaidDual(event: RewardPaidDual): void {
     event.address,
     event.block.timestamp,
     event.params.user,
+    true,
   )
 
   {
@@ -184,8 +212,12 @@ function handleEvent(
   boostedSavingsVaultAddress: Address,
   timestamp: BigInt,
   account: Address | null,
+  isDualVault: boolean,
 ): BoostedSavingsVaultEntity {
-  let boostedSavingsVaultEntity = BoostedSavingsVault.getOrCreate(boostedSavingsVaultAddress)
+  let boostedSavingsVaultEntity = BoostedSavingsVault.getOrCreate(
+    boostedSavingsVaultAddress,
+    isDualVault,
+  )
   boostedSavingsVaultEntity = BoostedSavingsVault.update(boostedSavingsVaultEntity)
   boostedSavingsVaultEntity.save()
 

--- a/packages/feeders/subgraph.template.yaml
+++ b/packages/feeders/subgraph.template.yaml
@@ -146,19 +146,25 @@ dataSources:
         - name: BoostedTokenWrapper
           file: ../../node_modules/@mstable/protocol/abis/BoostedTokenWrapper.json
       eventHandlers:
-        - event: Staked(indexed address,uint256,address)
-          handler: handleStaked
-        - event: Withdrawn(indexed address,uint256)
-          handler: handleWithdrawn
-        - event: Poked(indexed address)
-          handler: handlePoked
         {{#isDual}}
+        - event: Staked(indexed address,uint256,address)
+          handler: handleStakedDual
+        - event: Withdrawn(indexed address,uint256)
+          handler: handleWithdrawnDual
+        - event: Poked(indexed address)
+          handler: handlePokedDual
         - event: RewardAdded(uint256,uint256)
           handler: handleRewardAddedDual
         - event: RewardPaid(indexed address,uint256,uint256)
           handler: handleRewardPaidDual
         {{/isDual}}
         {{^isDual}}
+        - event: Staked(indexed address,uint256,address)
+          handler: handleStaked
+        - event: Withdrawn(indexed address,uint256)
+          handler: handleWithdrawn
+        - event: Poked(indexed address)
+          handler: handlePoked
         - event: RewardAdded(uint256)
           handler: handleRewardAdded
         - event: RewardPaid(indexed address,uint256)


### PR DESCRIPTION
- With tBTC v2 and others, not every dual vault has a platform token now; accommodate this by adding an explicit `isDualVault` flag to the vault entity, and check for that in the updating logic.